### PR TITLE
Add deprecation notice to README and as warning when activating

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # LVA Edge Graph Extension for VS Code
 
+⚠️ _This extension has been deprecated. Please use our updated extension instead: [Azure Video Analyzer](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.azure-video-analyzer)_
+
 Live Video Analytics on IoT Edge (LVA Edge) support for Visual Studio Code is provided through this extension that makes it easy to edit and manage LVA Edge media graphs.
 
 # What's New (v0.1.2)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "live-video-analytics-edge",
-    "displayName": "Live Video Analytics on IoT Edge",
+    "displayName": "[Deprecated] Live Video Analytics on IoT Edge",
     "description": "%extensionDescription%",
     "version": "0.1.2",
     "publisher": "ms-azuretools",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "live-video-analytics-edge",
     "displayName": "[Deprecated] Live Video Analytics on IoT Edge",
     "description": "%extensionDescription%",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "publisher": "ms-azuretools",
     "license": "SEE LICENSE IN LICENSE",
     "homepage": "https://github.com/Azure/lva-edge-vscode-extension",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,5 +1,5 @@
 {
-    "lva-edge.views.moduleExplorer.name": "Live Video Analytics",
+    "lva-edge.views.moduleExplorer.name": "Live Video Analytics [Deprecated]",
     "extensionDescription": "Live Video Analytics on IoT Edge support for Visual Studio Code is provided through this extension that makes it easy to edit and manage media graphs.",
     "deprecationNoticeMessage": "This extension has been deprecated. Please use our updated extension instead.",
     "deprecationNoticeShowNewExtension": "Show new extension",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,6 +1,8 @@
 {
     "lva-edge.views.moduleExplorer.name": "Live Video Analytics",
     "extensionDescription": "Live Video Analytics on IoT Edge support for Visual Studio Code is provided through this extension that makes it easy to edit and manage media graphs.",
+    "deprecationNoticeMessage": "This extension has been deprecated. Please use our updated extension instead.",
+    "deprecationNoticeShowNewExtension": "Show new extension",
     "connectionString.prompt": "Enter IoT hub connection string",
     "deviceList.prompt": "Select a device",
     "moduleList.prompt": "Select the Live Video Analytics module",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,7 +1,7 @@
 {
     "lva-edge.views.moduleExplorer.name": "Live Video Analytics [Deprecated]",
     "extensionDescription": "Live Video Analytics on IoT Edge support for Visual Studio Code is provided through this extension that makes it easy to edit and manage media graphs.",
-    "deprecationNoticeMessage": "This extension has been deprecated. Please use our updated extension instead.",
+    "deprecationNoticeMessage": "The Live Video Analytics extension has been deprecated. Please use the new Azure Video Analyzer extension instead.",
     "deprecationNoticeShowNewExtension": "Show new extension",
     "connectionString.prompt": "Enter IoT hub connection string",
     "deviceList.prompt": "Select a device",

--- a/src/Extension/extension.ts
+++ b/src/Extension/extension.ts
@@ -19,6 +19,14 @@ export async function activate(context: vscode.ExtensionContext) {
         moduleExplorer.setConnectionString(config);
     }
 
+    const showNewExtensionButton = Localizer.localize("deprecationNoticeShowNewExtension");
+    const newExtensionId = "ms-azuretools.azure-video-analyzer";
+    vscode.window.showWarningMessage(Localizer.localize("deprecationNoticeMessage"), showNewExtensionButton).then((choice) => {
+        if (choice === showNewExtensionButton) {
+            vscode.env.openExternal(vscode.Uri.parse("vscode:extension/" + newExtensionId));
+        }
+    });
+
     Constants.initialize(context);
 
     context.subscriptions.push(


### PR DESCRIPTION
The [Live Video Analytics on IoT Edge](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.live-video-analytics-edge) extension has been deprecated. This PR:
* adds a message to the README with a link to the new [Azure Video Analyzer](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.azure-video-analyzer) extension,
* updates the deprecated extension to show a warning message to the user when activating along with a button to show the new extension in the Marketplace, and
* adds `[Deprecated]` in the Marketplace title and extension sidebar header.

![image](https://user-images.githubusercontent.com/87671048/126715796-d497c20e-6fe2-429b-a22f-2b18878d5843.png)